### PR TITLE
wrap JSON.parse in a try

### DIFF
--- a/lib/logship.js
+++ b/lib/logship.js
@@ -55,7 +55,14 @@ function QpsmtpdToElastic (etcDir) {
     qp2e.reader = read.createReader(qp2e.cfg.reader.file, readerOpts)
     .on('read', function (data, lineCount) {
       logger.debug(lineCount); //  + ': ' + data);
-      qp2e.queue.push(JSON.parse(data));
+      try {
+        qp2e.queue.push(JSON.parse(data));
+      }
+      catch (e) {
+        logger.error(e);
+        logger.error('encountered while trying to parse: ');
+        logger.error(data);
+      }
     })
     .on('drain', function (done) {
       // logger.info('\tdrain: ' + qp2e.queue.length);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "log-ship-elastic-qpsmtpd",
   "description": "Ship Qpsmtpd logs to Elasticsearch",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": false,
   "keywords": [
     "log",


### PR DESCRIPTION
observed in the wild:

````
[SyntaxError: Unexpected token c]
trying to parse: 
{"connection":{"bytes":"20322","hello":{"hos...
````

on messages with a very, very, very long `to` field.

connected to dc/webui#340